### PR TITLE
Set env

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 # ts-lib-env-nodejs
 
+## v2.0.0 October 27, 2017 - joegoldbeck + alanjones
+- Remove hardcoded use of `process.env` in favor of `.setEnv` method
+- Add `.setTestMode` method
+
 ## v1.0.0 September 1, 2017 - joegoldbeck
 - Initial release

--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ const schema = object({
   VAR_THREE: boolean().optional(),
 });
 
-// process.env should already be set by environment
-
-// for ex, assume process.env is { VAR_ONE: 'foo', VAR_TWO: '2', ENV: 'production', SERVICE_NAME: 'bar', TENANT: 'multi' }
-
 const getEnv = tsEnv(schema); // always succeeds if schema itself is a valid Joi schema
 
 // module.exports = getEnv;
+
+getEnv.setEnv(process.env); // this sets the environment which backs the getEnv singleton
+                            // this should in general be set to process.env, and never changed
+                            // the one notable exception is for purposes of running automated tests
+
+// for ex, assume process.env is { VAR_ONE: 'foo', VAR_TWO: '2', ENV: 'production', SERVICE_NAME: 'bar', TENANT: 'multi' }
 
 // returns properly coerced value for allowed environment variables
 getEnv('VAR_ONE'); // 'foo'

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ getEnv('VAR_NOT_IN_SCHEMA'); // Uncaught Error ....
   * allowed values: any string
 * SERVICE_NAME
   * allowed values: any string ('multi', 'customer-1', 'customer-2')
+  
+### When writing tests
+
+getEnv.enterTestMode({env}); // this delays validation of your environment for this instance of getEnv
+                             // until variables are actually accessed in your application
+                             // it also resets the environment to whatever you pass in (default: {})
+
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -18,28 +18,42 @@ module.exports = (schema) => {
     }
   );
 
-  const { error, value } = Joi.validate(
-    process.env,
-    fullSchema,
-    {
-      stripUnknown: true,
-      noDefaults: true,
-      presence: 'required',
+  let env;
+  let validationResult;
+
+  const getEnv = function getEnv(variable) {
+    if (!validationResult) {
+      Joi.assert(env, object().required(), 'Env must be set through .setEnv prior to use');
+
+      validationResult = Joi.validate(
+        env,
+        fullSchema,
+        {
+          stripUnknown: true,
+          noDefaults: true,
+          presence: 'required',
+        }
+      );
+
+      Object.freeze(validationResult);
+
+      // set process.env.NODE_ENV to production by default in case express or anything else needs it
+      process.env.NODE_ENV = env.NODE_ENV || process.env.NODE_ENV || 'production';
     }
-  );
 
-  Object.freeze(value);
-
-  // set process.env.NODE_ENV to production by default in case express or anything else needs it
-  process.env.NODE_ENV = process.env.NODE_ENV || 'production';
-
-  return function getEnv(variable) {
-    if (error) throw error;
+    if (validationResult.error) throw validationResult.error;
 
     if (!Joi.reach(fullSchema, variable)) {
       throw new errors.ValidationError(`Requested environment variable "${variable}" not found`);
     }
 
-    return value[variable];
+    return validationResult.value[variable];
   };
+
+  getEnv.setEnv = (e) => {
+    env = e;
+    validationResult = null;
+  };
+
+  return getEnv;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-env",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "main": "index.js",
   "repository": "https://github.com/tetrascience/ts-lib-env-nodejs.git",

--- a/test/index.js
+++ b/test/index.js
@@ -26,16 +26,6 @@ describe('tsEnv', function() {
   });
 
   describe('getEnv', function() {
-    const env = Object.assign({}, process.env);
-
-    afterEach(() => {
-      process.env = {};
-    });
-
-    after(() => {
-      process.env = env;
-    });
-
     const schema = object().keys({
       str: string(),
       num: number(),
@@ -53,44 +43,44 @@ describe('tsEnv', function() {
     };
 
     it('accepts a string', function() {
-      process.env = validProcessEnv;
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(validProcessEnv);
 
       assert.doesNotThrow(() => getEnv('str'));
     });
 
     it('returns the value of the environment variable from process.env, properly coerced', function() {
-      process.env = validProcessEnv;
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(validProcessEnv);
 
       assert.equal(getEnv('str'), 'bar');
       assert.equal(getEnv('num'), 2);
     });
 
     it('returns the value of optional environment variables', function() {
-      process.env = validProcessEnv;
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(validProcessEnv);
 
       assert.equal(getEnv('optStr'), 'foofoo');
     });
 
     it('throws if requested environment variable is not defined in schema', function() {
-      process.env = validProcessEnv;
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(validProcessEnv);
 
       assert.throws(() => getEnv('baz'));
     });
 
     it('throws if any variable in process.env cannot be coerced to the correct type', function() {
-      process.env = Object.assign({ }, validProcessEnv, { num: 'two' });
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { num: 'two' }));
 
       assert.throws(() => getEnv('str'));
     });
 
     it('strips unknown environment variables', function() {
-      process.env = Object.assign({ foo: 'barbar' }, validProcessEnv);
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ foo: 'barbar' }, validProcessEnv));
 
       assert.throws(() => getEnv('foo'));
     });
@@ -98,8 +88,8 @@ describe('tsEnv', function() {
     it('throws if process.env is missing environment variables in schema', function() {
       const missingEnv = Object.assign({}, validProcessEnv);
       delete missingEnv.str;
-      process.env = missingEnv;
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(missingEnv);
 
       assert.throws(() => getEnv('ENV'));
     });
@@ -107,74 +97,75 @@ describe('tsEnv', function() {
     it('does not throw if optional environment variables in schema are not in process.env', function() {
       const optMissingEnv = Object.assign({}, validProcessEnv);
       delete optMissingEnv.foofoo;
-      process.env = optMissingEnv;
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(optMissingEnv);
 
       assert.doesNotThrow(() => getEnv('ENV'));
     });
 
     it('throws if forbidden environment variables in schema are in process.env', function() {
-      process.env = Object.assign({ forbStr: 'bar' }, validProcessEnv);
       const getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ forbStr: 'bar' }, validProcessEnv));
 
       assert.throws(() => getEnv('str'));
     });
 
     it('does not obey default values set in the schema', function() {
-      process.env = validProcessEnv;
       const getEnv = tsEnv(schema.keys({ str: string().default('baz') }));
+      getEnv.setEnv(validProcessEnv);
 
       assert.notEqual(getEnv('str'), 'baz');
       assert.equal(getEnv('str'), 'bar');
     });
 
     it('requires process.env.NODE_ENV to equal \'test\', \'local\', \'demo\', \'development\', \'staging\', \'production\'', function() {
-      process.env = Object.assign({ }, validProcessEnv, { ENV: 'foo' });
       let getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { ENV: 'foo' }));
       assert.throws(() => getEnv('str'));
 
-      process.env = Object.assign({ }, validProcessEnv, { ENV: 'test' });
       getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { ENV: 'test' }));
       assert.doesNotThrow(() => getEnv('str'));
 
-      process.env = Object.assign({ }, validProcessEnv, { ENV: 'local' });
       getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { ENV: 'local' }));
       assert.doesNotThrow(() => getEnv('str'));
 
-      process.env = Object.assign({ }, validProcessEnv, { ENV: 'demo' });
       getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { ENV: 'demo' }));
       assert.doesNotThrow(() => getEnv('str'));
 
-      process.env = Object.assign({ }, validProcessEnv, { ENV: 'development' });
       getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { ENV: 'development' }));
       assert.doesNotThrow(() => getEnv('str'));
 
-      process.env = Object.assign({ }, validProcessEnv, { ENV: 'staging' });
       getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { ENV: 'staging' }));
       assert.doesNotThrow(() => getEnv('str'));
 
-      process.env = Object.assign({ }, validProcessEnv, { ENV: 'production' });
       getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { ENV: 'production' }));
       assert.doesNotThrow(() => getEnv('str'));
     });
 
     it('requires process.env.SERVICE_NAME to be a non-empty string', function() {
-      process.env = Object.assign({ }, validProcessEnv, { SERVICE_NAME: '' });
       let getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { SERVICE_NAME: '' }));
       assert.throws(() => getEnv('str'));
 
-      process.env = Object.assign({ }, validProcessEnv, { SERVICE_NAME: 'foo' });
       getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { SERVICE_NAME: 'foo' }));
       assert.doesNotThrow(() => getEnv('str'));
     });
 
     it('requires process.env.TENANT to be a non-empty string', function() {
-      process.env = Object.assign({ }, validProcessEnv, { TENANT: '' });
       let getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { TENANT: '' }));
       assert.throws(() => getEnv('str'));
 
-      process.env = Object.assign({ }, validProcessEnv, { TENANT: 'foo' });
+
       getEnv = tsEnv(schema);
+      getEnv.setEnv(Object.assign({ }, validProcessEnv, { TENANT: 'foo' }));
       assert.doesNotThrow(() => getEnv('str'));
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,14 @@ describe('tsEnv', function() {
       optStr: 'foofoo',
     };
 
+    it('throws an error if setEnv hasnt been called with an object', function() {
+      const getEnv = tsEnv(schema);
+      assert.throws(() => getEnv('str'));
+      getEnv.setEnv('blah');
+      assert.throws(() => getEnv('str'));
+    });
+
+
     it('accepts a string', function() {
       const getEnv = tsEnv(schema);
       getEnv.setEnv(validProcessEnv);

--- a/test/index.js
+++ b/test/index.js
@@ -219,6 +219,14 @@ describe('tsEnv', function() {
 
         assert.throws(() => getEnv('foo'));
       });
+
+      it('resets the environment to {} if no argument passed', function() {
+        const getEnv = tsEnv(schema);
+        getEnv.setEnv(validProcessEnv);
+        getEnv.enterTestMode();
+
+        assert.throws(() => getEnv('num'));
+      });
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -176,5 +176,49 @@ describe('tsEnv', function() {
       getEnv.setEnv(Object.assign({ }, validProcessEnv, { TENANT: 'foo' }));
       assert.doesNotThrow(() => getEnv('str'));
     });
+    describe('in test mode', function(){
+      const partiallyValidProcessEnv = {
+        ENV: 'production',
+        SERVICE_NAME: 'foo',
+        TENANT: 'multi',
+        num: '2',
+        optStr: 'foofoo',
+      };
+
+      it('returns the value of environment variable which have been set, properly coerced', function() {
+        const getEnv = tsEnv(schema);
+        getEnv.enterTestMode(partiallyValidProcessEnv);
+
+        assert.equal(getEnv('num'), 2);
+      });
+
+      it('throws if value of requested environment variable has not been set', function() {
+        const getEnv = tsEnv(schema);
+        getEnv.enterTestMode(partiallyValidProcessEnv);
+
+        assert.throws(() => getEnv('str'));
+      });
+
+      it('throws if requested environment variable is not defined in schema', function() {
+        const getEnv = tsEnv(schema);
+        getEnv.enterTestMode(partiallyValidProcessEnv);
+
+        assert.throws(() => getEnv('baz'));
+      });
+
+      it('throws if requested variable in process.env cannot be coerced to the correct type', function() {
+        const getEnv = tsEnv(schema);
+        getEnv.enterTestMode(Object.assign({ }, validProcessEnv, { num: 'two' }));
+
+        assert.throws(() => getEnv('num'));
+      });
+
+      it('strips unknown environment variables', function() {
+        const getEnv = tsEnv(schema);
+        getEnv.enterTestMode(Object.assign({ foo: 'barbar' }, validProcessEnv));
+
+        assert.throws(() => getEnv('foo'));
+      });
+    });
   });
 });


### PR DESCRIPTION
Set environment via a method rather than getting process.env always

Here is a PR of a service using this proposed version of the library: https://github.com/tetrascience/ts-link-power-2/pull/19